### PR TITLE
Remove flutter key from pubspec

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,8 +4,6 @@ version: 0.0.2
 author: Leondev7 <leondev7jgt@gmail.com>
 homepage: https://github.com/Leondev7/flutter_fab_dialer
 
-flutter:
-
 dependencies:
   flutter:
     sdk: flutter


### PR DESCRIPTION
It isn't necessary and is causing error warnings in `flutter run`. See https://github.com/lejard-h/flutter_google_places_autocomplete/issues/4. Thanks @arc64 for the solution.