### PR TITLE
Option to select different animations for FAB showing.

### DIFF
--- a/lib/src/fab_dialer.dart
+++ b/lib/src/fab_dialer.dart
@@ -1,25 +1,34 @@
 part of flutter_fab_dialer;
 
+enum AnimationStyle {
+  fadeIn,
+  slideInDown,
+  defaultAnimation,
+}
+
 class FabDialer extends StatefulWidget {
-  const FabDialer(this._fabMiniMenuItemList, this._fabColor, this._fabIcon);
+  // AnimationStyle is an optional parameter to avoid breaking changes
+  const FabDialer(this._fabMiniMenuItemList, this._fabColor, this._fabIcon, [this._fabAnimationStyle = AnimationStyle.defaultAnimation]);
 
   final List<FabMiniMenuItem> _fabMiniMenuItemList;
   final Color _fabColor;
   final Icon _fabIcon;
+  final AnimationStyle _fabAnimationStyle;
 
   @override
   FabDialerState createState() =>
-      new FabDialerState(_fabMiniMenuItemList, _fabColor, _fabIcon);
+      new FabDialerState(_fabMiniMenuItemList, _fabColor, _fabIcon, _fabAnimationStyle);
 }
 
 class FabDialerState extends State<FabDialer> with TickerProviderStateMixin {
-  FabDialerState(this._fabMiniMenuItemList, this._fabColor, this._fabIcon);
+  FabDialerState(this._fabMiniMenuItemList, this._fabColor, this._fabIcon, this._fabAnimationStyle);
 
   int _angle = 90;
   bool _isRotated = true;
   final List<FabMiniMenuItem> _fabMiniMenuItemList;
   final Color _fabColor;
   final Icon _fabIcon;
+  final AnimationStyle _fabAnimationStyle;
   List<FabMenuMiniItemWidget> _fabMenuItems;
 
   AnimationController _controller;
@@ -51,6 +60,8 @@ class FabDialerState extends State<FabDialer> with TickerProviderStateMixin {
         fabColor: _fabMiniMenuItemList[i].fabColor,
         chipColor: _fabMiniMenuItemList[i].chipColor,
         controller: _controller,
+        animationStyle: _fabAnimationStyle,
+        itemCount: _fabMiniMenuItemList.length, // Send item count to each item to help animation calc
       ));
     }
 

--- a/lib/src/fab_menu_item.dart
+++ b/lib/src/fab_menu_item.dart
@@ -10,6 +10,7 @@ class FabMiniMenuItem {
    Color chipColor;
    String tooltip;
    Color textColor;
+   AnimationStyle animationStyle;
    OnFabMiniMenuItemPressed onPressed;
 
    FabMiniMenuItem.withText(
@@ -27,7 +28,6 @@ class FabMiniMenuItem {
     this.chipColor = null;
     this.textColor = null;
   }
-
 }
 
 class FabMenuMiniItemWidget extends StatelessWidget {
@@ -42,7 +42,9 @@ class FabMenuMiniItemWidget extends StatelessWidget {
       this.tooltip,
       this.index,
       this.controller,
-      this.onPressed})
+      this.onPressed,
+      this.animationStyle,
+      this.itemCount})
       : super(key: key);
   final double elevation;
   final String text;
@@ -52,51 +54,155 @@ class FabMenuMiniItemWidget extends StatelessWidget {
   final String tooltip;
   final Color textColor;
   final int index;
+  final int itemCount;
   final OnFabMiniMenuItemPressed onPressed;
   final AnimationController controller;
+  final AnimationStyle animationStyle;
+
+  Widget _buildAnimation(BuildContext context, Widget child) {
+    final double deviceHeight = MediaQuery.of(context).size.height;
+
+    switch (animationStyle) {
+      case AnimationStyle.fadeIn: //fadeIn
+        return new Container(
+          child: new Opacity(
+            opacity: new Tween<double>(
+              begin: 0.0,
+              end: 1.0,
+            )
+                .animate(
+              new CurvedAnimation(
+                parent: controller,
+                curve: new Interval(
+                  0.100,
+                  0.900,
+                  curve: Curves.easeIn,
+                ),
+              ),
+            )
+                .value,
+            child: new Container(
+              child: new Row(
+                children: <Widget>[
+                  new Container(
+                    child: _getChip(),
+                  ),
+                  new Padding(padding: const EdgeInsets.only(left: 10.0), child: _getFloatingActionButton()),
+                ],
+              ),
+            ),
+          ),
+        );
+      case AnimationStyle.slideInDown: // slideInDown:
+        return new Container(
+          padding: new EdgeInsetsTween(
+            end: const EdgeInsets.only(bottom: 0.0),
+            begin: EdgeInsets.only(top: deviceHeight / itemCount / 3),
+          )
+              .animate(
+            new CurvedAnimation(
+              parent: controller,
+              curve: new Interval(
+                0.100,
+                0.600,
+                curve: Curves.fastOutSlowIn,
+              ),
+            ),
+          )
+              .value,
+          child: new Opacity(
+            opacity: new Tween<double>(
+              begin: 0.0,
+              end: 1.0,
+            )
+                .animate(
+              new CurvedAnimation(
+                parent: controller,
+                curve: new Interval(
+                  0.100,
+                  0.600,
+                  curve: Curves.ease,
+                ),
+              ),
+            )
+                .value,
+            child: new Container(
+              child: new Row(
+                children: <Widget>[
+                  new Container(
+                    child: _getChip(),
+                  ),
+                  new Padding(padding: const EdgeInsets.only(left: 10.0), child: _getFloatingActionButton()),
+                ],
+              ),
+            ),
+          ),
+        );
+      default:
+        return new Container(
+          child: new Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: <Widget>[
+              new Container(
+                margin: new EdgeInsets.symmetric(horizontal: 8.0),
+                child: new ScaleTransition(
+                  scale: new CurvedAnimation(
+                    parent: controller,
+                    curve: new Interval(((index + 1) / 10), 1.0, curve: Curves.linear),
+                  ),
+                  child: _getChip(),
+                ),
+              ),
+              new ScaleTransition(
+                scale: new CurvedAnimation(
+                  parent: controller,
+                  curve: new Interval(((index + 1) / 10), 1.0, curve: Curves.linear),
+                ),
+                child: _getFloatingActionButton(),
+              )
+            ],
+          ),
+        );
+    }
+  }
+
+  Widget _getChip() {
+    return chipColor != null
+        ? new Chip(
+      label: new Text(
+        text,
+        textAlign: TextAlign.center,
+        overflow: TextOverflow.ellipsis,
+        style: new TextStyle(color: textColor, fontWeight: FontWeight.bold),
+      ),
+    )
+        : null;
+  }
+
+  Widget _getFloatingActionButton() {
+    return new FloatingActionButton(
+        elevation: elevation,
+        mini: true,
+        backgroundColor: fabColor,
+        tooltip: tooltip,
+        child: icon,
+        heroTag: "$index",
+        onPressed: onPressed);
+  }
 
   @override
   Widget build(BuildContext context) {
     return new Container(
-        margin: new EdgeInsets.symmetric(vertical: 5.0, horizontal: 8.0),
-        child: new Row(
-          mainAxisAlignment: MainAxisAlignment.end,
-          children: <Widget>[
-            new Container(
-                margin: new EdgeInsets.symmetric(horizontal: 8.0),
-                child: new ScaleTransition(
-                    scale: new CurvedAnimation(
-                      parent: controller,
-                      curve: new Interval(((index + 1) / 10), 1.0,
-                          curve: Curves.linear),
-                    ),
-                    child: chipColor!=null
-                        ?new Chip(
-                      label: new Text(
-                        text,
-                        textAlign: TextAlign.center,
-                        overflow: TextOverflow.ellipsis,
-                        style: new TextStyle(
-                            color: textColor, fontWeight: FontWeight.bold),
-                      ),
-                      backgroundColor: chipColor,
-                    ):null)),
-            new ScaleTransition(
-              scale: new CurvedAnimation(
-                parent: controller,
-                curve:
-                    new Interval(((index + 1) / 10), 1.0, curve: Curves.linear),
-              ),
-              child: new FloatingActionButton(
-                  elevation: elevation,
-                  mini: true,
-                  backgroundColor: fabColor,
-                  tooltip: 'Increment',
-                  child: icon,
-                  heroTag: "$index",
-                  onPressed: onPressed),
-            )
-          ],
-        ));
+      margin: new EdgeInsets.symmetric(vertical: 5.0, horizontal: 8.0),
+      child: new Row(
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: <Widget>[
+          new AnimatedBuilder(
+            builder: _buildAnimation,
+            animation: controller,
+          ),
+        ],
+      ),
+    );
   }
 }


### PR DESCRIPTION
You can select different animations for showing the FAB buttons.

In **_fab_dialer.dart_**, I did create another constructor parameter (optional) that allow passing an enumeration item for different animations. Using this optional parameter we can avoid any breaking changes. If this parameter is omitted then the default animation (current animation = scale) will take place.

I added 2 new animations using "Staggered animation": fadeIn (fade all small FAB buttons and text) and slideInDown (slide each small FAB button from top to the correct position). More animations can be added later.

How to call:
```
// Default call without selecting the animation
new FabDialer( [ ... <items> ...], Colors.red, new Icon(Icons.add));
or
// Default call selecting a different animation
new FabDialer( [ ... <items> ...], Colors.red, new Icon(Icons.add), AnimationStyle.slideInDown);
```
Tested up to 9 items in an IPhone 7 and up to 9 items in and Nexus 6P.

Must update documentation, maybe add a gif with each different animations.