### PR TITLE
Fix margin that causes strange hero tag effect

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -63,6 +63,10 @@ class _MyHomePageState extends State<MyHomePage> {
     });
   }
 
+  void _navigateToAnotherScreen() {
+    Navigator.of(context).push(MaterialPageRoute(builder: (_) => AnotherScreen()));
+  }
+
   @override
   Widget build(BuildContext context) {
     //The list of FabMiniMenuItems that we are going to use
@@ -82,7 +86,7 @@ class _MyHomePageState extends State<MyHomePage> {
           Colors.white,
           true),
       new FabMiniMenuItem.noText(new Icon(Icons.add), Colors.blue, 4.0,
-          "Button menu", _logCounter, false),
+          "Navigate new screen", _navigateToAnotherScreen, false),
       new FabMiniMenuItem.noTextWithImage(
           img, 4.0, "Button menu", _incrementCounter, false)
     ];
@@ -105,6 +109,23 @@ class _MyHomePageState extends State<MyHomePage> {
           ),
           new FabDialer(_fabMiniMenuItemList, Colors.blue, new Icon(Icons.add)),
         ],
+      ),
+    );
+  }
+}
+
+class AnotherScreen extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text("Testing"),
+      ),
+      floatingActionButton: FloatingActionButton(
+        child: Icon(Icons.add),
+        onPressed: () {
+          Navigator.of(context).pop();
+        }
       ),
     );
   }

--- a/lib/src/fab_dialer.dart
+++ b/lib/src/fab_dialer.dart
@@ -85,7 +85,7 @@ class FabDialerState extends State<FabDialer> with TickerProviderStateMixin {
   @override
   Widget build(BuildContext context) {
     return new Container(
-        margin: new EdgeInsets.symmetric(vertical: 10.0, horizontal: 10.0),
+        margin: new EdgeInsets.symmetric(vertical: 16.0, horizontal: 16.0),
         child: new Column(
           mainAxisAlignment: MainAxisAlignment.end,
           children: <Widget>[


### PR DESCRIPTION
Because of different margin and default hero tag when I was navigation between screens that use your lib and default floating action button could see a strange move to adapt to the new position, so I fixed it adjusting to the same position of default FAB

### Before
![before](https://user-images.githubusercontent.com/10780132/51542107-9a2f2800-1e41-11e9-9942-03ba999ac987.gif)

### After
![after](https://user-images.githubusercontent.com/10780132/51542078-8b487580-1e41-11e9-8e6b-964f638d6743.gif)


I also add in example this navigation between those screens 