### PR TITLE
Added onTap functionality to the Chip of FabMiniMenuItem

### DIFF
--- a/lib/src/fab_menu_item.dart
+++ b/lib/src/fab_menu_item.dart
@@ -203,20 +203,27 @@ class FabMenuMiniItemWidget extends StatelessWidget {
     }
   }
 
-  Widget _getChip() {
+Widget _getChip() {
     return chipColor != null
         ? new Chip(
             backgroundColor: chipColor,
-            label: new Text(
-              text,
-              textAlign: TextAlign.center,
-              overflow: TextOverflow.ellipsis,
-              style:
-                  new TextStyle(color: textColor, fontWeight: FontWeight.bold),
+            label: new InkWell(
+              onTap: () {
+                onPressed();
+                hideWidget == null ? null : hideWidget();
+              },
+              child: new Text(
+                text,
+                textAlign: TextAlign.center,
+                overflow: TextOverflow.ellipsis,
+                style: new TextStyle(
+                    color: textColor, fontWeight: FontWeight.bold),
+              ),
             ),
           )
         : null;
   }
+
 
   Widget _getFloatingActionButton() {
     return fabColor != null


### PR DESCRIPTION
During the Usability testing of an App that I am creating, people were tapping on the chip of the `FabMiniMenuItem.withText`. I had to add it to the application via changing the source code just a tiny bit. Then I thought it would be important for the future as well. Kindly accept this pull request.